### PR TITLE
Appended Docker file and added script 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,19 @@ RUN sed -i 's_DocumentRoot /var/www/html_DocumentRoot /var/www/html/app_' /etc/a
 WORKDIR "/var/www/html"
 #RUN npm cache clean && npm install
 
+ENV  APACHE_RUN_USER=www-data \
+        APACHE_RUN_GROUP=www-data \
+        APACHE_LOG_DIR=/var/log/apache2 \
+        APACHE_LOCK_DIR=/var/lock/apache2 \
+        APACHE_RUN_DIR=/var/run/apache2 \
+        APACHE_PID_FILE=/var/run/apache2.pid 
+
+COPY ./scripts/* /scripts/
+
+RUN chmod +x /scripts/*
+
+CMD ["/scripts/boot.sh"]
+
 
 #ADD run.sh /run.sh
 RUN chmod 0755 /var/www/html/run.sh

--- a/scripts/boot.sh
+++ b/scripts/boot.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+if [ ! -d "$APACHE_RUN_DIR" ]; then
+	mkdir "$APACHE_RUN_DIR"
+	chown $APACHE_RUN_USER:$APACHE_RUN_GROUP "$APACHE_RUN_DIR"
+fi
+if [ -f "$APACHE_PID_FILE" ]; then
+	rm "$APACHE_PID_FILE"
+fi
+/usr/sbin/apache2ctl -D FOREGROUND


### PR DESCRIPTION
Added script in the docker file to remove the existing PIDs of apache2 when the container is built. Also added a boot.sh script. Dockerfile will setup the variables and boot.sh does the rest. ( The issue was observed while automating the SP deployment process where the son-gui was unable to exit cleanly and was erroring out during next start)
